### PR TITLE
Fixes infinite loading when attestation tx fails or gets rejected

### DIFF
--- a/src/app/(dashboard)/attestation/attestationModal.tsx
+++ b/src/app/(dashboard)/attestation/attestationModal.tsx
@@ -42,6 +42,8 @@ export function GenerateAttestationModal({
   const [attestationPrivateData, setAttestationPrivateData] = useState<any>();
   const [attestationPublicData, setAttestationPublicData] =
     useState<AttestationPublicDataDto>();
+  const [attestationCreationError, setAttestationCreationError] =
+    useState<boolean>(false);
   const [registeredAttestationUuid, setRegisteredAttestationUuid] = useState<
     string | undefined
   >(undefined);
@@ -101,6 +103,8 @@ export function GenerateAttestationModal({
             userSalt,
           );
           console.log(JSON.stringify(proof));
+        } else if (attestationUuid === null) {
+          setAttestationCreationError(true);
         }
       });
     }
@@ -125,6 +129,8 @@ export function GenerateAttestationModal({
             attestationUuid.attestationUuid,
             chainId,
           );
+        } else if (attestationUuid === null) {
+          setAttestationCreationError(true);
         }
       });
     }
@@ -181,11 +187,13 @@ export function GenerateAttestationModal({
           <PrivateAttestationDialogContent
             registeredAttestationUuid={registeredAttestationUuid}
             easscanUrl={easscanUrl}
+            createAttestationError={attestationCreationError}
           />
         ) : createTypeAttestation == "public" ? (
           <PublicAttestationDialogContent
             registeredAttestationUuid={registeredAttestationUuid}
             easscanUrl={easscanUrl}
+            createAttestationError={attestationCreationError}
           />
         ) : (
           <ChooseTypeAttestationDialogContent

--- a/src/app/(dashboard)/attestation/utils/attestation-utils.ts
+++ b/src/app/(dashboard)/attestation/utils/attestation-utils.ts
@@ -92,18 +92,23 @@ export async function createPrivateAttestation({
     { name: "privateData", value: merkleRoot, type: "bytes32" },
   ]);
 
-  const tx = await eas.attest({
-    schema: schemaUID,
-    data: {
-      recipient: address,
-      expirationTime: undefined,
-      revocable: false,
-      data: encodedData,
-    },
-  });
-  const attestationUuid = await tx.wait();
+  try {
+    const tx = await eas.attest({
+      schema: schemaUID,
+      data: {
+        recipient: address,
+        expirationTime: undefined,
+        revocable: false,
+        data: encodedData,
+      },
+    });
+    const attestationUuid = await tx.wait();
 
-  return { attestationUuid: attestationUuid };
+    return { attestationUuid: attestationUuid };
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
 }
 
 export async function createPublicAttestation({
@@ -164,18 +169,23 @@ export async function createPublicAttestation({
       type: "string",
     },
   ]);
-  const tx = await eas.attest({
-    schema: schemaUID,
-    data: {
-      recipient: address,
-      expirationTime: undefined,
-      revocable: false,
-      data: encodedData,
-    },
-  });
-  const attestationUuid = await tx.wait();
+  try {
+    const tx = await eas.attest({
+      schema: schemaUID,
+      data: {
+        recipient: address,
+        expirationTime: undefined,
+        revocable: false,
+        data: encodedData,
+      },
+    });
+    const attestationUuid = await tx.wait();
 
-  return { attestationUuid: attestationUuid };
+    return { attestationUuid: attestationUuid };
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
 }
 
 export function createMerkleTree(

--- a/src/components/attestations/privateAttestationDialogContent.tsx
+++ b/src/components/attestations/privateAttestationDialogContent.tsx
@@ -11,11 +11,13 @@ import { useRouter } from "next/navigation";
 interface AttestationDialogContentProps {
   registeredAttestationUuid?: string;
   easscanUrl: string;
+  createAttestationError?: boolean;
 }
 
 export function PrivateAttestationDialogContent({
   registeredAttestationUuid,
   easscanUrl,
+  createAttestationError,
 }: AttestationDialogContentProps) {
   const router = useRouter();
 
@@ -52,7 +54,16 @@ export function PrivateAttestationDialogContent({
             </div>
           </div>
         ) : (
-          <LoadingCircle></LoadingCircle>
+          <div>
+            {createAttestationError ? (
+              <div>
+                {" "}
+                Creating the attestation has failed, please try again 🥺
+              </div>
+            ) : (
+              <LoadingCircle></LoadingCircle>
+            )}
+          </div>
         )}
       </div>
     </>

--- a/src/components/attestations/publicAttestationDialogContent.tsx
+++ b/src/components/attestations/publicAttestationDialogContent.tsx
@@ -10,11 +10,13 @@ import {
 interface AttestationDialogContentProps {
   registeredAttestationUuid?: string;
   easscanUrl: string;
+  createAttestationError?: boolean;
 }
 
 export function PublicAttestationDialogContent({
   registeredAttestationUuid,
   easscanUrl,
+  createAttestationError,
 }: AttestationDialogContentProps) {
   return (
     <>
@@ -40,7 +42,13 @@ export function PublicAttestationDialogContent({
             </div>
           </div>
         ) : (
-          <LoadingCircle></LoadingCircle>
+          <div>
+            {createAttestationError ? (
+              <div> The attestation has failed, please try again 🥺</div>
+            ) : (
+              <LoadingCircle></LoadingCircle>
+            )}
+          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds a try/catch when sending the TX for creating the attestations, and it avoids the attestation modal to be kept in loading state forever when a tx fails or the user rejects the tx

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue
https://github.com/armitage-labs/armitage-monorepo/issues/136


## Screenshots (if appropriate):

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read Armitage Contributing Guide
  - 📖 Read Armitage Code of Conduct
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
